### PR TITLE
Simplify setup of comparator function in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,10 @@ cmp.setup {
     -- ... rest of your setup ...
 
     sorting = {
-        comparators = {
-            cmp.config.compare.offset,
-            cmp.config.compare.exact,
-            cmp.config.compare.score,
-            require "cmp-under-comparator".under,
-            cmp.config.compare.kind,
-            cmp.config.compare.sort_text,
-            cmp.config.compare.length,
-            cmp.config.compare.order,
-        },
+        comparators = table.insert(
+            cmp.config.compare,
+            require('cmp-under-comparator').under
+        ),
     },
 }
 ```


### PR DESCRIPTION
This has the benefit that if new comparators are added to nvim-cmp,
this plugin's setup section will not have to be updated.
Also it's less code in a user's config file :)

Not sure if there is a better alternative compared to `vim.list_extend`.

**Edit**: I changed it to `table.insert`.